### PR TITLE
Adding 0.0.0.0 to stubby.yml

### DIFF
--- a/stubby.yml
+++ b/stubby.yml
@@ -117,7 +117,7 @@ tls_ca_path: "/etc/ssl/certs/"
 # and IPv6. It will listen on port 53 by default. Use <IP_address>@<port> to
 # specify a different port
 listen_addresses:
-  - 127.0.0.1@8053
+  - 0.0.0.0@8053
   - 0::1@8053
 
 ############################### DNSSEC SETTINGS ################################
@@ -214,7 +214,7 @@ upstream_recursive_servers:
 #    tls_auth_name: "getdnsapi.net"
 #    tls_pubkey_pinset:
 #      - digest: "sha256"
-        value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
+#       value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
 
 
 ############################ OPTIONAL UPSTREAMS  ###############################

--- a/stubby.yml
+++ b/stubby.yml
@@ -117,7 +117,9 @@ tls_ca_path: "/etc/ssl/certs/"
 # and IPv6. It will listen on port 53 by default. Use <IP_address>@<port> to
 # specify a different port
 listen_addresses:
-  - 0.0.0.0@8053
+# If you're using docker, uncomment to allow stubby to listen on Docker Bridge Network
+#  - 0.0.0.0@8053
+  - 127.0.0.1@8053
   - 0::1@8053
 
 ############################### DNSSEC SETTINGS ################################


### PR DESCRIPTION
By default, Docker will use **Bridge Network Mode** on new Containers.

Listening to **0.0.0.0** will also make Stubby listen to the IP Address designated by Docker, so we can access it from other containers and from Docker Host.